### PR TITLE
Remove notificações vazias do iOS

### DIFF
--- a/ios/Classes/service/BackgroundService.swift
+++ b/ios/Classes/service/BackgroundService.swift
@@ -156,7 +156,7 @@ class BackgroundService: NSObject {
   }
   
   private func requestNotification() {
-    if !notificationOptions.showNotification {
+    if !notificationOptions.showNotification || notificationContent.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
       return
     }
     


### PR DESCRIPTION
Corrige: Toda vez que eu abro o app com uma corrida em andamento, aparece essa notificação vazia, que some depois
https://github.com/gaudiumsoftware/mchapp-passageiro-flutter/pull/851