### PR TITLE
Correção de crash de lateinit no onDestroy

### DIFF
--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -194,6 +194,12 @@ class ForegroundService : Service() {
         if (::foregroundServiceStatus.isInitialized) {
             isCorrectlyStopped = foregroundServiceStatus.isCorrectlyStopped()
         }
+
+        if (!::foregroundTaskOptions.isInitialized) {
+            Log.e(TAG, "foregroundTaskOptions was not properly started.")
+            return
+        }
+
         val allowAutoRestart = foregroundTaskOptions.allowAutoRestart
         if (allowAutoRestart && !isCorrectlyStopped && !ForegroundServiceUtils.isSetStopWithTaskFlag(this)) {
             Log.e(TAG, "The service will be restarted after 5 seconds because it wasn't properly stopped.")


### PR DESCRIPTION
Corrige um crash em [ForegroundService.onDestroy](https://console.firebase.google.com/project/map-for-work-asset-113551911/crashlytics/app/android:br.com.urbanonorte.passenger.drivermachine/issues/93d9797929bb5a046d6421e3cb009c76?time=7d&types=crash&sessionEventKey=68E01F8900ED0001773AD4BCB71A2BDF_2135520451726655584) que consistia no acesso à variável lateinit foregroundTaskOptions ainda não inicializada.