### PR TITLE
Correção de crash no ForegroundService.attachForegroundTask

### DIFF
--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -174,7 +174,7 @@ class ForegroundService : Service() {
             }
         } catch (e: Exception) {
             Log.e(TAG, e.message, e)
-            stopForegroundService(true)
+            stopForegroundService(false)
         }
 
         return if (isSetStopWithTaskFlag) {


### PR DESCRIPTION
Evita tentar dar attach do foreground service ao ocorrer exceção… na primeira vez que tentou fazer onStartCommand

⚠️ Não mergear, apenas deixar a branch para que o app aponte para ela para subir para uma central separada.